### PR TITLE
Upgrade from connect 1.8.7 to 2.29.1 (latest 2.x)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "dependencies": {
         "async": "~0.9.0",
         "colors": "~1.0.3",
-        "connect": "1.8.7",
+        "connect": "2.29.1",
+        "express-session": "~1.11.0",
+        "urlrouter": "~0.5.4",
         "optimist": "~0.6.1",
         "msgpack-js-browser": "~0.1.4",
         "engine.io": "~1.5.1",

--- a/plugins-server/cloud9.alive/alive.js
+++ b/plugins-server/cloud9.alive/alive.js
@@ -20,7 +20,7 @@ module.exports = function setup(options, imports, register) {
         }
     }
 
-    imports.connect.useStart(imports.connect.getModule().router(function(app) {
+    imports.connect.useStart(imports.connect.getRouter()(function(app) {
         app.get(/^\/alive$/, function(req, res) {
             checkAlive(req, res);
         });

--- a/plugins-server/cloud9.core/ide.js
+++ b/plugins-server/cloud9.core/ide.js
@@ -146,7 +146,7 @@ util.inherits(Ide, EventEmitter);
             packedName: this.options.packedName,
             local: this.options.local,
             loadedDetectionScript: loadedDetectionScript,
-            _csrf: req.session && req.session._csrf || ""
+            _csrf: req.csrfToken() || ""
         };
 
         var settingsPlugin = this.workspace.getExt("settings");

--- a/plugins-server/cloud9.debug/debug.js
+++ b/plugins-server/cloud9.debug/debug.js
@@ -1,17 +1,17 @@
 
 module.exports = function setup(options, imports, register) {
 
-    imports.connect.useStart(imports.connect.getModule().router(function(app) {
+    imports.connect.useStart(imports.connect.getRouter()(function(app) {
         app.post(/^\/api\/debug$/, function(req, res) {
             imports.connect.getModule().bodyParser()(req, res, function() {
 
                 imports.log.error("[CLIENT ERROR]", req.body);
-    
+
                 res.writeHead(200, {"Content-Type": "text/plain"});
                 res.end("OK");
             });
         });
     }));
-    
+
     register(null, {});
 };

--- a/plugins-server/cloud9.ide.filelist/filelist-plugin.js
+++ b/plugins-server/cloud9.ide.filelist/filelist-plugin.js
@@ -11,7 +11,6 @@ var Url = require("url");
 var Plugin = require("../cloud9.core/plugin");
 var FilelistLib = require("./filelist");
 var util = require("util");
-var Connect = require("connect");
 var error = require("http-error");
 
 var name = "filelist";
@@ -40,7 +39,7 @@ module.exports = function setup(options, imports, register) {
 
         // set up some routes as well
         var self = this;
-        IdeRoutes.use("/fs", Connect.router(function(app) {
+        IdeRoutes.use("/fs", imports.connect.getRouter()(function(app) {
             app.get("/list", self.getList.bind(self));
         }));
     };
@@ -72,7 +71,7 @@ module.exports = function setup(options, imports, register) {
                         if (!msg)
                             return;
 
-                        if (!res.headerSent)
+                        if (!res.headersSent)
                             res.writeHead(200, { "content-type": "text/plain" });
                         res.write(msg);
                     },

--- a/plugins-server/cloud9.ide.filelist/package.json
+++ b/plugins-server/cloud9.ide.filelist/package.json
@@ -9,7 +9,8 @@
             "ide",
             "vfs",
             "ide-routes",
-            "workspace-permissions"
+            "workspace-permissions",
+            "connect"
         ]
     }
 }

--- a/plugins-server/connect.session.file/session-ext.js
+++ b/plugins-server/connect.session.file/session-ext.js
@@ -1,13 +1,13 @@
 var assert = require("assert");
 var path = require("path");
 var fs = require("fs");
-var Store = require("connect/lib/middleware/session/store");
+var Store = require("express-session/session/store");
 var exists = fs.existsSync || path.existsSync;
 
 module.exports = function startup(options, imports, register) {
 
     assert(options.sessionsPath, "option 'sessionsPath' is required");
-    
+
     if (!exists(path.dirname(options.sessionsPath))) {
         fs.mkdir(path.dirname(options.sessionsPath), 0755);
     }
@@ -19,7 +19,7 @@ module.exports = function startup(options, imports, register) {
         basePath: options.sessionsPath,
         reapInterval: options.maxAge || 60 * 60 * 1000    // 1 hour
     });
-    
+
     register(null, {
         "session-store": {
             on: sessionStore.on.bind(sessionStore),
@@ -29,7 +29,7 @@ module.exports = function startup(options, imports, register) {
             createSession: sessionStore.createSession.bind(sessionStore)
         }
     });
-    
+
 };
 
 
@@ -58,7 +58,7 @@ var FileStore = function(options) {
                             // session ok
                         } else {
                             self.destroy(file);
-                        }                      
+                        }
                     });
                 });
             });
@@ -93,14 +93,14 @@ FileStore.prototype.get = function(sid, fn){
                       fn(null, sess);
                   } else {
                       self.destroy(sid, fn);
-                  }                      
+                  }
               }
           });
       }
       else {
           fn();
       }
-  });      
+  });
 };
 
 FileStore.prototype.set = function(sid, sess, fn){
@@ -129,7 +129,7 @@ FileStore.prototype.destroy = function(sid, fn){
               else {
                   fn && fn();
               }
-          });              
+          });
       } else {
           fn && fn();
       }

--- a/plugins-server/connect.static/static-plugin.js
+++ b/plugins-server/connect.static/static-plugin.js
@@ -10,7 +10,7 @@ module.exports = function startup(options, imports, register) {
     var workerPrefix = options.workerPrefix || "/static";
 
     var connect = imports.connect.getModule();
-    var staticServer = connect.createServer();
+    var staticServer = connect();
     imports.connect.useMain(options.bindPrefix || prefix, staticServer);
 
     register(null, {
@@ -25,7 +25,7 @@ module.exports = function startup(options, imports, register) {
                 statics.forEach(function(s) {
 
 //                    console.log("MOUNT", prefix, s.mount, s.path);
-                    
+
                     if (s.router) {
                         var server = connect.static(s.path);
                         staticServer.use(s.mount, function(req, res, next) {
@@ -62,7 +62,7 @@ module.exports = function startup(options, imports, register) {
             getStaticPrefix: function() {
                 return prefix;
             },
-            
+
             getWorkerPrefix: function() {
                 return workerPrefix;
             }

--- a/plugins-server/connect/connect-plugin.js
+++ b/plugins-server/connect/connect-plugin.js
@@ -1,6 +1,7 @@
 var utils = require("connect/lib/utils");
 var netutil = require("netutil");
 var connect = require("connect");
+var router = require("urlrouter");
 
 module.exports = function startup(options, imports, register) {
     imports.log.info("connect plugin start");
@@ -21,6 +22,9 @@ module.exports = function startup(options, imports, register) {
         },
         getUtils: function() {
             return utils;
+        },
+        getRouter: function() {
+            return router;
         }
     };
     hookNames.forEach(function(name) {
@@ -28,9 +32,9 @@ module.exports = function startup(options, imports, register) {
         server.use(hookServer);
         api["use" + name] = function() {
             hookServer.use.apply(hookServer, arguments);
-            
+
             var route = hookServer.stack[hookServer.stack.length-1];
-            
+
             // return "unuse"
             return function() {
                 var i = hookServer.stack.indexOf(route);
@@ -66,7 +70,7 @@ module.exports = function startup(options, imports, register) {
             return host;
         };
 
-        server.listen(port, host, function(err) {
+        var getListen = server.listen(port, host, function(err) {
             if (err)
                 return register(err);
 
@@ -80,7 +84,7 @@ module.exports = function startup(options, imports, register) {
                 "connect": api,
                 "http": {
                     getServer: function() {
-                        return server;
+                        return getListen;
                     }
                 }
             });


### PR DESCRIPTION
- Gemnasium reported cross-site vulnerability for connect and in general the version used is ancient
- Added express-session
- Added urlrouter
- Biggest change from 1.x to 2.x: connect() no longer returns http.Server object. Instead it is returned in connect.listen() This broke engine.io, smith.io and terminal
- In connect 2.7.4 session#save() errors started to be printed to console. This created new ENOENT, rename errors to console. I believe functionality has not changed.
- Deprecation notice for multipart ( being called in connect.bodyParser() )